### PR TITLE
28 Add no trailing punctuation rule

### DIFF
--- a/rules/config.go
+++ b/rules/config.go
@@ -10,9 +10,10 @@ import (
 )
 
 type ProjectConfig struct {
-	emailDomains  []string
-	maxCharacters int
-	ticketRegexp  string
+	emailDomains                 []string
+	maxCharacters                int
+	ticketRegexp                 string
+	noTrailingPunctuationInTitle bool
 }
 
 var k = koanf.New(".")

--- a/rules/no_trailing_punctuation.go
+++ b/rules/no_trailing_punctuation.go
@@ -1,0 +1,21 @@
+package rules
+
+import (
+	"gitlab.com/tbacompany/gitector/reader"
+	"strings"
+)
+
+type TrailingPunctationInTitle struct{}
+
+func CheckForTrailingPunctuationInTitle(title string) bool {
+	return !strings.ContainsAny(title, ".")
+}
+
+func CheckForTrailingPunctuationInTitleError(commit reader.GitCommit) GitError {
+	return GitError{
+		ErrorType:   NotValidEmails{},
+		Title:       "Trailing Punctuation not allowed in title",
+		Description: "Commit title should not contain trailing punctuation",
+		Commit:      commit,
+	}
+}

--- a/rules/no_trailing_punctuation.go
+++ b/rules/no_trailing_punctuation.go
@@ -8,7 +8,14 @@ import (
 type TrailingPunctationInTitle struct{}
 
 func CheckForTrailingPunctuationInTitle(title string) bool {
-	return !strings.ContainsAny(title, ".")
+	parts := strings.Split(title, ".")
+	if len(parts) == 1 {
+		return true
+	}
+	if strings.TrimSpace(parts[len(parts)-1]) == "" {
+		return false
+	}
+	return true
 }
 
 func CheckForTrailingPunctuationInTitleError(commit reader.GitCommit) GitError {

--- a/rules/no_trailing_punctuation_test.go
+++ b/rules/no_trailing_punctuation_test.go
@@ -1,0 +1,21 @@
+package rules
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSuccessIfPassesForEmptyTitle(t *testing.T) {
+	title := ""
+	assert.True(t, CheckForTrailingPunctuationInTitle(title))
+}
+
+func TestFailsIfTrailingPunctuationInTitle(t *testing.T) {
+	title := "Add new feature."
+	assert.False(t, CheckForTrailingPunctuationInTitle(title))
+}
+
+func TestSuccessIfNoTrailingPunctuation(t *testing.T) {
+	title := "Add new feature"
+	assert.True(t, CheckForTrailingPunctuationInTitle(title))
+}

--- a/rules/no_trailing_punctuation_test.go
+++ b/rules/no_trailing_punctuation_test.go
@@ -19,3 +19,18 @@ func TestSuccessIfNoTrailingPunctuation(t *testing.T) {
 	title := "Add new feature"
 	assert.True(t, CheckForTrailingPunctuationInTitle(title))
 }
+
+func TestIfPassesIfDotInMiddleOfTitle(t *testing.T) {
+	title := "Add Test. Add else new feature "
+	assert.True(t, CheckForTrailingPunctuationInTitle(title))
+}
+
+func TestIfPassesIfMultipleDotsInMiddleOfTitle(t *testing.T) {
+	title := "Add [...] new feature"
+	assert.True(t, CheckForTrailingPunctuationInTitle(title))
+}
+
+func TestFailsPassesIfDotFollowedBySpace(t *testing.T) {
+	title := "Add [...] new feature. "
+	assert.False(t, CheckForTrailingPunctuationInTitle(title))
+}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -46,5 +46,9 @@ func singleCommit(description reader.GitCommit, config ProjectConfig) []GitError
 		errors = append(errors, EmptyLineBetweenError(description))
 	}
 
+	if config.noTrailingPunctuationInTitle && !CheckForTrailingPunctuationInTitle(description.Title) {
+		errors = append(errors, CheckForTrailingPunctuationInTitleError(description))
+	}
+
 	return errors
 }

--- a/utils/init.go
+++ b/utils/init.go
@@ -9,7 +9,8 @@ var defaultConfig = []byte(`
 {
   "allowed_domains": [],
   "title_max_characters": 72,
-  "ticket_regexp": ""
+  "ticket_regexp": "",
+   "no_trailing_punctuation_in_title": true
 }
 `)
 


### PR DESCRIPTION
Add new rule which checks if trailing punctation is used.

- Updated default config to include new check