### PR TITLE
NO-TICKET Add JSON serializer for output

### DIFF
--- a/app.go
+++ b/app.go
@@ -80,6 +80,8 @@ func generateErrorOutput(format string, errors []rules.GitError) string {
 		return printer.GenerateHTML(errors)
 	case "markdown":
 		return printer.GenerateMarkdown(errors)
+	case "json":
+		return printer.GenerateJSON(errors)
 	default:
 		return printer.GenerateConsoleErrors(errors)
 	}

--- a/printer/json.go
+++ b/printer/json.go
@@ -1,0 +1,29 @@
+package printer
+
+import (
+	"encoding/json"
+	"gitlab.com/tbacompany/gitector/rules"
+)
+
+type jsonWrapper struct {
+	Errors []jsonError `json:"errors"`
+}
+
+type jsonError struct {
+	Error       string `json:"error"`
+	CommitTitle string `json:"commit_title"`
+}
+
+func GenerateJSON(errors []rules.GitError) string {
+	jsonErrors := []jsonError{}
+
+	for _, element := range errors {
+		jsonErrors = append(jsonErrors, jsonError{
+			Error:       element.Title,
+			CommitTitle: element.Commit.Title,
+		})
+
+	}
+	bytes, _ := json.Marshal(jsonWrapper{jsonErrors})
+	return string(bytes)
+}

--- a/printer/json_test.go
+++ b/printer/json_test.go
@@ -1,0 +1,14 @@
+package printer
+
+import (
+	"github.com/stretchr/testify/assert"
+	"gitlab.com/tbacompany/gitector/reader"
+	"gitlab.com/tbacompany/gitector/rules"
+	"testing"
+)
+
+func TestJsonContainesPassedErrors(t *testing.T) {
+	errors := []rules.GitError{{Title: "test", Commit: reader.GitCommit{Title: "Test"}}, {Title: "test2", Commit: reader.GitCommit{Title: "Test2"}}}
+	expectedRes := `{"errors":[{"error":"test","commit_title":"Test"},{"error":"test2","commit_title":"Test2"}]}`
+	assert.Equal(t, expectedRes, GenerateJSON(errors))
+}


### PR DESCRIPTION
Add JSON serializer as output. This allows chaning gitector with other tools which can accept json