### PR TITLE
Add verbose logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build: gitector
+build:
 	go build
 
 install: build

--- a/app.go
+++ b/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/op/go-logging"
 
 	"github.com/urfave/cli"
 	"gitlab.com/tbacompany/gitector/printer"
@@ -39,9 +40,20 @@ func CreateNewApp() *cli.App {
 			Name:  "direct-input, di",
 			Usage: "Use direct input ",
 		},
+		cli.BoolFlag{
+			Name:  "verbose",
+			Usage: "Print additional debug info",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
+		// Set logging level
+		if c.Bool("verbose") {
+			logging.SetLevel(logging.INFO, "")
+		} else {
+			logging.SetLevel(logging.DEBUG, "")
+		}
+
 		// gitScope is defined same way as git diff does it branch..branch or commit..commit
 		gitScope := "master.."
 		if c.NArg() > 0 {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bclicn/color v0.0.0-20180711051946-108f2023dc84
 	github.com/gobuffalo/packr v1.30.1
 	github.com/knadh/koanf v0.5.0
+	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.22.1
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
+github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfSeg=

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"gitlab.com/tbacompany/gitector/reader"
+	"log"
 	"strings"
 )
 
@@ -12,11 +13,12 @@ type GitError struct {
 	Commit      reader.GitCommit
 }
 
-func Rules(description []reader.GitCommit, directory string) []GitError {
+func Rules(commits []reader.GitCommit, directory string) []GitError {
 	config := ReadConfig(directory)
 	var errors []GitError
-	for _, elem := range description {
-		foundErrors := singleCommit(elem, config)
+	for _, commit := range commits {
+		foundErrors := singleCommit(commit, config)
+		log.Printf("Found %d issues for commit %s ", len(foundErrors), commit.Title)
 		errors = append(errors, foundErrors...)
 	}
 	return errors

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -1,8 +1,8 @@
 package rules
 
 import (
+	"github.com/op/go-logging"
 	"gitlab.com/tbacompany/gitector/reader"
-	"log"
 	"strings"
 )
 
@@ -13,12 +13,14 @@ type GitError struct {
 	Commit      reader.GitCommit
 }
 
+var log = logging.MustGetLogger("")
+
 func Rules(commits []reader.GitCommit, directory string) []GitError {
 	config := ReadConfig(directory)
 	var errors []GitError
 	for _, commit := range commits {
 		foundErrors := singleCommit(commit, config)
-		log.Printf("Found %d issues for commit %s ", len(foundErrors), commit.Title)
+		log.Debugf("Found %d issues for commit %s ", len(foundErrors), commit.Title)
 		errors = append(errors, foundErrors...)
 	}
 	return errors


### PR DESCRIPTION
## Problem:
When running app, it's not visible which commits were exactly tested. If they don't fail on any check there is no information if they were checked. In case of debuging configuration by end user it might be usefull to see how evaluation of rules apply.

## Proposed solution

Add debug level logs to check which rules were evaluated